### PR TITLE
[building] use config.logdir with the new ccbuilder

### DIFF
--- a/bisector.py
+++ b/bisector.py
@@ -450,7 +450,9 @@ if __name__ == "__main__":
     config, args = utils.get_config_and_parser(parsers.bisector_parser())
 
     patchdb = PatchDB(config.patchdb)
-    bldr = BuilderWithCache(Path(config.cachedir), patchdb, args.cores)
+    bldr = BuilderWithCache(
+        Path(config.cachedir), patchdb, args.cores, logdir=Path(config.logdir)
+    )
     chkr = checker.Checker(config, bldr)
     gnrtr = generator.CSmithCaseGenerator(config, patchdb, args.cores)
     rdcr = reducer.Reducer(config, bldr)

--- a/checker.py
+++ b/checker.py
@@ -491,7 +491,9 @@ if __name__ == "__main__":
     config, args = utils.get_config_and_parser(parsers.checker_parser())
 
     patchdb = PatchDB(config.patchdb)
-    bldr = BuilderWithCache(Path(config.cachedir), patchdb, args.cores)
+    bldr = BuilderWithCache(
+        Path(config.cachedir), patchdb, args.cores, logdir=Path(config.logdir)
+    )
     chkr = Checker(config, bldr)
 
     file = Path(args.file)

--- a/generator.py
+++ b/generator.py
@@ -141,7 +141,7 @@ class CSmithCaseGenerator:
     ):
         self.config: utils.NestedNamespace = config
         self.builder: BuilderWithCache = BuilderWithCache(
-            Path(config.cachedir), patchdb, cores
+            Path(config.cachedir), patchdb, cores, logdir=Path(config.logdir)
         )
         self.chkr: checker.Checker = checker.Checker(config, self.builder)
         self.procs: list[Process] = []

--- a/main.py
+++ b/main.py
@@ -1324,7 +1324,9 @@ if __name__ == "__main__":
     config, args = utils.get_config_and_parser(parsers.main_parser())
 
     patchdb = PatchDB(config.patchdb)
-    bldr = BuilderWithCache(Path(config.cachedir), patchdb, args.cores)
+    bldr = BuilderWithCache(
+        Path(config.cachedir), patchdb, args.cores, logdir=Path(config.logdir)
+    )
     chkr = checker.Checker(config, bldr)
     gnrtr = generator.CSmithCaseGenerator(config, patchdb, args.cores)
     rdcr = reducer.Reducer(config, bldr)

--- a/reducer.py
+++ b/reducer.py
@@ -216,7 +216,9 @@ if __name__ == "__main__":
     config, args = utils.get_config_and_parser(parsers.reducer_parser())
 
     patchdb = PatchDB(config.patchdb)
-    bldr = BuilderWithCache(Path(config.cachedir), patchdb, args.cores)
+    bldr = BuilderWithCache(
+        Path(config.cachedir), patchdb, args.cores, logdir=Path(config.logdir)
+    )
     gnrtr = generator.CSmithCaseGenerator(config, patchdb)
     rdcr = Reducer(config, bldr)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 dead-instrumenter>=0.0.2
-ccbuilder>=0.0.4
+ccbuilder>=0.0.5
 requests>=2.27.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 attrs>=21.4.0
 black>=21.12b0
-ccbuilder>=0.0.4
+ccbuilder>=0.0.5
 click>=8.0.3
 dead-instrumenter>=0.0.2
 importlab>=0.7


### PR DESCRIPTION
I forgot to create an option to override the `logdir` in ccbuilder.
This results in dead creating two  `logdir`s at the moment: `config.logdir` and `$cachedir/logs`. 

With https://github.com/DeadCodeProductions/ccbuilder/commit/622166e528eb219e42b32500c47329f12302f671 ccbuilder will have such an option.

The changes here should hand over `config.logdir` to all `BuilderWithCache`.

The tests fail as the changes to ccbuilder are not on pypi yet. 