### PR TITLE
[requirements] make dependencies strict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dead-instrumenter>=0.0.2
-ccbuilder>=0.0.5
+dead-instrumenter==0.0.2
+ccbuilder==0.0.5
 requests>=2.27.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,8 +1,8 @@
 attrs>=21.4.0
 black>=21.12b0
-ccbuilder>=0.0.5
+ccbuilder==0.0.5
 click>=8.0.3
-dead-instrumenter>=0.0.2
+dead-instrumenter==0.0.2
 importlab>=0.7
 libcst>=0.4.0
 mypy>=0.931


### PR DESCRIPTION
As `dead_instrumenter` and especially `ccbuilder` are under active development with breaking changes, the requirements should be strict. 