### PR TITLE
Update dead_instrumenter dependency and fix CCC cmake

### DIFF
--- a/callchain_checker/CMakeLists.txt
+++ b/callchain_checker/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(callchain_checker CXX)
+project(callchain_checker C CXX)
 
 find_package(Boost REQUIRED)
 message(STATUS "Found Boost ${Boost_VERSION_STRING}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dead-instrumenter==0.0.2
+dead-instrumenter==0.0.3
 ccbuilder==0.0.5
 requests>=2.27.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,7 @@ attrs>=21.4.0
 black>=21.12b0
 ccbuilder==0.0.5
 click>=8.0.3
-dead-instrumenter==0.0.2
+dead-instrumenter==0.0.3
 importlab>=0.7
 libcst>=0.4.0
 mypy>=0.931


### PR DESCRIPTION
dead_instrumenter has the issue of pulling the current main branch when
building the binary to instrument. This will break dead over time.
Version 0.0.3 of dead fixes which version is pulled for building the
binary.