### PR TITLE
[parsers] default cores value

### DIFF
--- a/parsers.py
+++ b/parsers.py
@@ -1,4 +1,5 @@
 import argparse
+import multiprocessing as mp
 from typing import Any, Sequence
 
 
@@ -20,7 +21,10 @@ def config_parser(
     )
 
     parser.add_argument(
-        "--cores", help="Amount of build cores to use. Defaults to all.", type=int
+        "--cores",
+        help="Amount of build cores to use. Defaults to all.",
+        type=int,
+        default=mp.cpu_count(),
     )
 
     return parser

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 attrs>=21.4.0
-black>=21.12b0
+black>=21.12b0,<=22.12.0
 ccbuilder==0.0.5
 click>=8.0.3
 dead-instrumenter==0.0.3


### PR DESCRIPTION
parser claims that the default value is all cores but it is not, causing a crash when `--cores` is not specified.