### PR TITLE
Stronger sanity check

### DIFF
--- a/checker.py
+++ b/checker.py
@@ -38,7 +38,7 @@ def get_cc_output(cc: str, file: Path, flags: str, cc_timeout: int) -> tuple[int
         "-Wall",
         "-Wextra",
         "-Wpedantic",
-        "-O1",
+        "-O3",
         "-Wno-builtin-declaration-mismatch",
     ]
     if flags:
@@ -116,6 +116,7 @@ def check_compiler_warnings(
         "return type of ‘main’ is not ‘int’",
         "past the end of the array",
         "no return statement in function returning non-void",
+        "undefined behavior",
     ]
 
     ws = [w for w in warnings if w in clang_output or w in gcc_output]
@@ -199,7 +200,7 @@ def use_ub_sanitizers(
     Returns:
         bool: True if no undefined was found.
     """
-    cmd = [clang, str(file), "-O1", "-fsanitize=undefined,address"]
+    cmd = [clang, str(file), "-O0", "-fsanitize=undefined,address"]
     if flags:
         cmd.extend(flags.split())
 


### PR DESCRIPTION
Recently, an undefined behavior warning was missed because: a) we did not check for it
b) It was only found on higher optimization levels. Hence the increase of the sanity check to -O2.