### PR TITLE
Fix checker copy past error

### DIFF
--- a/checker.py
+++ b/checker.py
@@ -386,7 +386,7 @@ class Checker:
             if m:
                 empty_body_code += (
                     "\n"
-                    + rf"void {marker_prefix}{m.group(1)}(m.group(2)){{}}"
+                    + rf"void {marker_prefix}{m.group(1)}({m.group(2)}){{}}"
                     + "\n"
                     + rf"{m.group(3)}"
                 )


### PR DESCRIPTION
Once upon a time, last week, I was merrily on my way into the weekend when I encountered an interesting new behaviour/bug. Luckily, the root of the issue was quickly determined and a fix, tested manually, was found.
However, this fix was written inside an ephemeral vessel and needed to be rescued before falling to the into the depth of accidentally closing the container.
"Surely I can just retype the fix to save it. It is of such short length!" I thought to myself.
In the back of my mind, I heard R.B., someone I studied with, repeating himself: "Repetition hides errors, repetition hides errors." but I swiftly ignored this voice.