### PR TITLE
Add detection of conditional jumps as markers

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -890,7 +890,7 @@ def find_alive_markers(
     alive_markers = set()
 
     # Extract alive markers
-    alive_regex = re.compile(f".*[call|jmp].*{marker_prefix}([0-9]+)_.*")
+    alive_regex = re.compile(f".*(?:call|j[a-z]{{1,2}}).*{marker_prefix}([0-9]+)_.*")
 
     asm = get_asm_str(code, compiler_setting, bldr)
 


### PR DESCRIPTION
This PR includes support for detecting conditional jumps as markers. Thus, if the compiler creates a conditional jump to the marker, DEAD will now be able to detect the marker, too. 